### PR TITLE
Draft: Add reliability tuning knobs for timeout and lookup concurrency

### DIFF
--- a/docs/work-items/issue-4-reliability-tuning.md
+++ b/docs/work-items/issue-4-reliability-tuning.md
@@ -1,0 +1,15 @@
+# Work Item for Issue #4
+
+Issue: https://github.com/johnstel/AzureMaccAnalyst/issues/4
+
+## Scope
+- Add reliability tuning knobs for timeout and lookup concurrency
+
+## Implementation checklist
+- [ ] Add env var for CSV price lookup worker count
+- [ ] Tune safer defaults for timeout and worker count
+- [ ] Document knobs in finops_app README
+
+## Validation
+- [ ] Run app against large CSV and compare warning count
+- [ ] Confirm analysis still completes and exports successfully


### PR DESCRIPTION
## Summary
Adds a scoped implementation plan for issue #4.

## Scope in this PR
- Adds [docs/work-items/issue-4-reliability-tuning.md](docs/work-items/issue-4-reliability-tuning.md)

## Linked issue
Closes #4